### PR TITLE
Improve user select prevention for keyboard on iOS

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -196,6 +196,8 @@ header {
     width: 100%;
     justify-content: center;
     margin-bottom: 6px;
+    user-select: none;
+    -webkit-user-select: none; /* Prevent selection on iOS */
 }
 
 .keyboard-second {
@@ -221,6 +223,7 @@ header {
     touch-action: none;
     cursor: pointer;
     user-select: none;
+    -webkit-user-select: none; /* Prevent selection on iOS */
 
     font-weight: bold;
     padding: 0.5em 0.5em;


### PR DESCRIPTION
iOS needs the `-webkit` prefix to actually disable user’s selection.

See: https://caniuse.com/mdn-css_properties_user-select