### PR TITLE
Persist statistics when updated

### DIFF
--- a/src/manager.rs
+++ b/src/manager.rs
@@ -466,6 +466,7 @@ impl Manager {
                 self.max_streak = streak;
             }
         }
+        let _res = self.persist();
     }
 
     #[cfg(web_sys_unstable_apis)]


### PR DESCRIPTION
Currently, statistics are only persisted when settings are changed. Probably just a minor oversight, but this should fix it.