### PR TITLE
When hovering over the title-icon, display a pointer instead of edit

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -89,6 +89,7 @@ header {
     letter-spacing: 0.2rem;
     text-transform: uppercase;
     text-align: center;
+    cursor: pointer;
 }
 
 .title {


### PR DESCRIPTION
This pull request includes a small change to the `static/styles.css` file. The change adds a pointer cursor to the `title-icon` class to improve user interaction.

* [`static/styles.css`](diffhunk://#diff-2339bc0791b9baa744347f95fa5d5010d723aba0623fd3b6b22b76a4a1583775R92): Added `cursor: pointer` to the `title-icon` class to indicate that it is clickable.