### PR TITLE
Fix clippy lints and warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,6 @@ opt-level = 'z'
 # opt-level = 's'
 # link time optimization using using whole-program analysis
 lto = true
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(web_sys_unstable_apis)'] }

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ To set the flag manually with environment variables, run:
 export RUSTFLAGS=--cfg=web_sys_unstable_apis
 ```
 
-You can ignore this at manual development (as the clipboard API won't work without HTTPS anywaays)
+You can ignore this at manual development (as the clipboard API won't work without HTTPS anyways)
 or run your trunk commands with it set.
 
 For normal development, start the web server with

--- a/src/components/board.rs
+++ b/src/components/board.rs
@@ -33,7 +33,7 @@ pub fn board(props: &Props) -> Html {
                 }
             }
             <div class={classes!(
-                props.is_reset.then(|| "slide-in"),
+                props.is_reset.then_some("slide-in"),
                 props.is_reset.then(|| format!("slide-in-{}", props.previous_guesses.len())),
                 format!("board-{}", props.max_guesses))}>{
                     props.guesses.iter().enumerate().map(|(row, guess)| {
@@ -51,7 +51,7 @@ pub fn board(props: &Props) -> Html {
                                             <div class={classes!(
                                                 "tile",
                                                 tile_state.to_string(),
-                                                is_current_row.then(|| Some("current"))
+                                                is_current_row.then_some(Some("current"))
                                             )}>
                                                 {
                                                     if props.is_hidden {

--- a/src/components/modal.rs
+++ b/src/components/modal.rs
@@ -153,11 +153,11 @@ pub fn menu_modal(props: &MenuModalProps) -> Html {
                         <div>
                             <label class="label">{"Sanulien pituus:"}</label>
                             <div class="select-container">
-                                <button class={classes!("select", (props.word_length == 5).then(|| Some("select-active")))}
+                                <button class={classes!("select", (props.word_length == 5).then_some(Some("select-active")))}
                                     onmousedown={change_word_length_5}>
                                     {"5 merkkiä"}
                                 </button>
-                                <button class={classes!("select", (props.word_length == 6).then(|| Some("select-active")))}
+                                <button class={classes!("select", (props.word_length == 6).then_some(Some("select-active")))}
                                     onmousedown={change_word_length_6}>
                                     {"6 merkkiä"}
                                 </button>
@@ -166,15 +166,15 @@ pub fn menu_modal(props: &MenuModalProps) -> Html {
                         <div>
                             <label class="label">{"Sanulista:"}</label>
                             <div class="select-container">
-                                <button class={classes!("select", (props.current_word_list == WordList::Easy).then(|| Some("select-active")))}
+                                <button class={classes!("select", (props.current_word_list == WordList::Easy).then_some(Some("select-active")))}
                                     onmousedown={change_word_list_easy}>
                                     {"Helppo"}
                                 </button>
-                                <button class={classes!("select", (props.current_word_list == WordList::Common).then(|| Some("select-active")))}
+                                <button class={classes!("select", (props.current_word_list == WordList::Common).then_some(Some("select-active")))}
                                     onmousedown={change_word_list_common}>
                                     {"Tavallinen"}
                                 </button>
-                                <button class={classes!("select", (props.current_word_list == WordList::Full).then(|| Some("select-active")))}
+                                <button class={classes!("select", (props.current_word_list == WordList::Full).then_some(Some("select-active")))}
                                     onmousedown={change_word_list_full}>
                                     {"Vaikea"}
                                 </button>
@@ -183,11 +183,11 @@ pub fn menu_modal(props: &MenuModalProps) -> Html {
                         <div>
                             <label class="label">{"Rumat sanulit:"}</label>
                             <div class="select-container">
-                                <button class={classes!("select", (!props.allow_profanities).then(|| Some("select-active")))}
+                                <button class={classes!("select", (!props.allow_profanities).then_some(Some("select-active")))}
                                     onmousedown={change_allow_profanities_no}>
                                     {"Ei"}
                                 </button>
-                                <button class={classes!("select", (props.allow_profanities).then(|| Some("select-active")))}
+                                <button class={classes!("select", (props.allow_profanities).then_some(Some("select-active")))}
                                     onmousedown={change_allow_profanities_yes}>
                                     {"Kyllä"}
                                 </button>
@@ -201,15 +201,15 @@ pub fn menu_modal(props: &MenuModalProps) -> Html {
             <div>
                 <label class="label">{"Pelimuoto:"}</label>
                 <div class="select-container">
-                    <button class={classes!("select", (props.game_mode == GameMode::Classic).then(|| Some("select-active")))}
+                    <button class={classes!("select", (props.game_mode == GameMode::Classic).then_some(Some("select-active")))}
                         onmousedown={change_game_mode_classic}>
                         {"Peruspeli"}
                     </button>
-                    <button class={classes!("select", (props.game_mode == GameMode::Relay).then(|| Some("select-active")))}
+                    <button class={classes!("select", (props.game_mode == GameMode::Relay).then_some(Some("select-active")))}
                         onmousedown={change_game_mode_relay}>
                         {"Sanuliketju"}
                     </button>
-                    <button class={classes!("select", (props.game_mode == GameMode::Quadruple).then(|| Some("select-active")))}
+                    <button class={classes!("select", (props.game_mode == GameMode::Quadruple).then_some(Some("select-active")))}
                         onmousedown={change_game_mode_quadruple}>
                         {"Neluli"}
                     </button>
@@ -230,11 +230,11 @@ pub fn menu_modal(props: &MenuModalProps) -> Html {
             <div>
                 <label class="label">{"Teema:"}</label>
                 <div class="select-container">
-                    <button class={classes!("select", (props.theme == Theme::Dark).then(|| Some("select-active")))}
+                    <button class={classes!("select", (props.theme == Theme::Dark).then_some(Some("select-active")))}
                         onmousedown={change_theme_dark}>
                         {"Oletus"}
                     </button>
-                    <button class={classes!("select", (props.theme == Theme::Colorblind).then(|| Some("select-active")))}
+                    <button class={classes!("select", (props.theme == Theme::Colorblind).then_some(Some("select-active")))}
                         onmousedown={change_theme_colorblind}>
                         {"Värisokeille"}
                     </button>

--- a/src/game.rs
+++ b/src/game.rs
@@ -6,13 +6,11 @@ pub type KnownStates = HashMap<(char, usize), CharacterState>;
 pub type KnownCounts = HashMap<char, CharacterCount>;
 
 use crate::manager::{
-    CharacterCount, CharacterState, GameMode, KeyState, Theme, TileState, WordList,
+    CharacterCount, CharacterState, GameMode, KeyState, TileState, WordList
 };
 
-pub const SUCCESS_EMOJIS: [&str; 9] = ["🥳", "🤩", "🤗", "🎉", "😊", "😺", "😎", "👏", ":3"];
-pub const DEFAULT_WORD_LENGTH: usize = 5;
-pub const DEFAULT_MAX_GUESSES: usize = 6;
-pub const DEFAULT_ALLOW_PROFANITIES: bool = false;
+#[cfg(web_sys_unstable_apis)]
+use crate::manager::Theme;
 
 pub trait Game {
     fn title(&self) -> String;
@@ -21,7 +19,9 @@ pub trait Game {
     fn submit_guess(&mut self);
     fn push_character(&mut self, character: char);
     fn pop_character(&mut self);
+    #[cfg(web_sys_unstable_apis)]
     fn share_emojis(&self, theme: Theme) -> Option<String>;
+    #[cfg(web_sys_unstable_apis)]
     fn share_link(&self) -> Option<String>;
     fn reveal_hidden_tiles(&mut self);
     fn reset(&mut self);

--- a/src/game.rs
+++ b/src/game.rs
@@ -161,7 +161,7 @@ pub fn board_tile_state(
 ) -> TileState {
     match states[current_guess].get(&(*character, index)) {
         Some(CharacterState::Correct) => {
-            return TileState::Correct;
+            TileState::Correct
         }
         Some(CharacterState::Absent) => {
             let revealed = revealed_counts
@@ -176,15 +176,15 @@ pub fn board_tile_state(
             match discovered_count {
                 CharacterCount::AtLeast(count) | CharacterCount::Exactly(count) => {
                     if *revealed <= *count {
-                        return TileState::Present;
+                        TileState::Present
                     } else {
-                        return TileState::Absent;
+                        TileState::Absent
                     }
                 }
             }
         }
         _ => {
-            return TileState::Unknown;
+            TileState::Unknown
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,12 +122,10 @@ impl Component for App {
                 if let Some(game) = &self.manager.game {
                     if game.is_guessing() {
                         link.send_message(Msg::Guess);
+                    } else if matches!(game.game_mode(), GameMode::DailyWord(_) | GameMode::Shared) {
+                        link.send_message(Msg::ChangePreviousGameMode);
                     } else {
-                        if matches!(game.game_mode(), GameMode::DailyWord(_) | GameMode::Shared) {
-                            link.send_message(Msg::ChangePreviousGameMode);
-                        } else {
-                            link.send_message(Msg::NextWord);
-                        }
+                        link.send_message(Msg::NextWord);
                     }
                 }
             }
@@ -274,7 +272,7 @@ impl Component for App {
                         is_hidden={game.is_hidden()}
                         is_emojis_copied={self.is_emojis_copied}
                         is_link_copied={self.is_link_copied}
-                        game_mode={game.game_mode().clone()}
+                        game_mode={*game.game_mode()}
                         message={game.message()}
                         word={game.word().iter().collect::<String>()}
                         last_guess={last_guess}

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -40,7 +40,7 @@ fn parse_all_words() -> Rc<WordLists> {
         let word_length = chars.clone().count();
         word_lists
             .entry((WordList::Full, word_length))
-            .or_insert_with(HashSet::new)
+            .or_default()
             .insert(chars.collect());
     }
 
@@ -50,7 +50,7 @@ fn parse_all_words() -> Rc<WordLists> {
         let word_length = chars.clone().count();
         word_lists
             .entry((WordList::Easy, word_length))
-            .or_insert_with(HashSet::new)
+            .or_default()
             .insert(chars.collect());
     }
 
@@ -62,13 +62,13 @@ fn parse_all_words() -> Rc<WordLists> {
             // TODO: Fake 6-letter easy words from common words, get rid of this if the list is created
             word_lists
                 .entry((WordList::Easy, 6))
-                .or_insert_with(HashSet::new)
+                .or_default()
                 .insert(chars.clone().collect());
         }
 
         word_lists
             .entry((WordList::Common, word_length))
-            .or_insert_with(HashSet::new)
+            .or_default()
             .insert(chars.collect());
     }
 
@@ -77,7 +77,7 @@ fn parse_all_words() -> Rc<WordLists> {
         let word_length = chars.clone().count();
         word_lists
             .entry((WordList::Profanities, word_length))
-            .or_insert_with(HashSet::new)
+            .or_default()
             .insert(chars.collect());
     }
 
@@ -85,22 +85,21 @@ fn parse_all_words() -> Rc<WordLists> {
 }
 
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize)]
+#[derive(Default)]
 pub enum WordList {
     Full,
+    #[default]
     Common,
     Easy,
     Profanities,
     Daily,
 }
 
-impl Default for WordList {
-    fn default() -> Self {
-        WordList::Common
-    }
-}
 
 #[derive(PartialEq, Eq, Hash, Clone, Copy, Serialize, Deserialize)]
+#[derive(Default)]
 pub enum GameMode {
+    #[default]
     Classic,
     Relay,
     DailyWord(NaiveDate),
@@ -108,23 +107,15 @@ pub enum GameMode {
     Quadruple,
 }
 
-impl Default for GameMode {
-    fn default() -> Self {
-        GameMode::Classic
-    }
-}
 
 #[derive(PartialEq, Clone, Copy, Serialize, Deserialize)]
+#[derive(Default)]
 pub enum Theme {
+    #[default]
     Dark,
     Colorblind,
 }
 
-impl Default for Theme {
-    fn default() -> Self {
-        Theme::Dark
-    }
-}
 
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub enum CharacterState {
@@ -341,7 +332,7 @@ impl Manager {
             }
         }
 
-        return None;
+        None
     }
 
     pub fn push_character(&mut self, character: char) {

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -25,6 +25,8 @@ pub const DEFAULT_MAX_GUESSES: usize = 6;
 pub const DEFAULT_ALLOW_PROFANITIES: bool = false;
 pub const DAILY_WORD_LEN: usize = 5;
 
+pub const SUCCESS_EMOJIS: [&str; 9] = ["🥳", "🤩", "🤗", "🎉", "😊", "😺", "😎", "👏", ":3"];
+
 pub type WordLists = HashMap<(WordList, usize), HashSet<Vec<char>>>;
 
 #[derive(PartialEq, Copy, Clone)]

--- a/src/neluli.rs
+++ b/src/neluli.rs
@@ -5,9 +5,15 @@ use std::rc::Rc;
 use gloo_storage::{errors::StorageError, LocalStorage, Storage};
 use serde::{Deserialize, Serialize};
 
-use crate::game::{Board, Game, DEFAULT_ALLOW_PROFANITIES, DEFAULT_WORD_LENGTH, SUCCESS_EMOJIS};
-use crate::manager::{GameMode, KeyState, Theme, TileState, WordList, WordLists};
+use crate::game::{Board, Game};
+use crate::manager::{
+    GameMode, KeyState, TileState, WordList, WordLists,
+    DEFAULT_ALLOW_PROFANITIES, DEFAULT_WORD_LENGTH, SUCCESS_EMOJIS,
+};
 use crate::sanuli::Sanuli;
+
+#[cfg(web_sys_unstable_apis)]
+use crate::manager::Theme;
 
 const MAX_GUESSES: usize = 9;
 
@@ -315,10 +321,12 @@ impl Game for Neluli {
         }
     }
 
+    #[cfg(web_sys_unstable_apis)]
     fn share_emojis(&self, _theme: Theme) -> Option<String> {
         unimplemented!()
     }
 
+    #[cfg(web_sys_unstable_apis)]
     fn share_link(&self) -> Option<String> {
         unimplemented!()
     }

--- a/src/sanuli.rs
+++ b/src/sanuli.rs
@@ -6,19 +6,22 @@ use std::rc::Rc;
 use chrono::NaiveDate;
 use gloo_storage::{errors::StorageError, LocalStorage, Storage};
 use serde::{Deserialize, Serialize};
+
+#[cfg(web_sys_unstable_apis)]
 use web_sys::{window, Window};
 
 pub type KnownStates = HashMap<(char, usize), CharacterState>;
 pub type KnownCounts = HashMap<char, CharacterCount>;
 
 use crate::game;
-use crate::game::{
-    Board, Game, DEFAULT_ALLOW_PROFANITIES, DEFAULT_MAX_GUESSES, DEFAULT_WORD_LENGTH,
-    SUCCESS_EMOJIS,
-};
+use crate::game::{Board, Game};
 use crate::manager::{
-    CharacterCount, CharacterState, GameMode, KeyState, Theme, TileState, WordList, WordLists,
+    CharacterCount, CharacterState, GameMode, KeyState, TileState, WordList, WordLists,
+    DEFAULT_ALLOW_PROFANITIES, DEFAULT_MAX_GUESSES, DEFAULT_WORD_LENGTH, SUCCESS_EMOJIS,
 };
+
+#[cfg(web_sys_unstable_apis)]
+use crate::manager::Theme;
 
 const DAILY_WORDS: &str = include_str!("../daily-words.txt");
 
@@ -567,6 +570,7 @@ impl Game for Sanuli {
         self.guesses[self.current_guess].pop();
     }
 
+    #[cfg(web_sys_unstable_apis)]
     fn share_emojis(&self, theme: Theme) -> Option<String> {
         let mut message = String::new();
 
@@ -609,6 +613,7 @@ impl Game for Sanuli {
         Some(message)
     }
 
+    #[cfg(web_sys_unstable_apis)]
     fn share_link(&self) -> Option<String> {
         let game_str = format!(
             "{}|{}",

--- a/src/sanuli.rs
+++ b/src/sanuli.rs
@@ -78,16 +78,13 @@ impl Sanuli {
         allow_profanities: bool,
         word_lists: Rc<WordLists>,
     ) -> Self {
-        let guesses = std::iter::repeat(Vec::with_capacity(word_length))
-            .take(max_guesses)
+        let guesses = std::iter::repeat_n(Vec::with_capacity(word_length), max_guesses)
             .collect::<Vec<_>>();
 
-        let known_states = std::iter::repeat(HashMap::new())
-            .take(max_guesses)
+        let known_states = std::iter::repeat_n(HashMap::new(), max_guesses)
             .collect::<Vec<_>>();
 
-        let known_counts = std::iter::repeat(HashMap::new())
-            .take(max_guesses)
+        let known_counts = std::iter::repeat_n(HashMap::new(), max_guesses)
             .collect::<Vec<_>>();
 
         let word = if word_lists.is_empty() {
@@ -147,12 +144,10 @@ impl Sanuli {
 
         guesses.resize(max_guesses, Vec::with_capacity(word_length));
 
-        let known_states = std::iter::repeat(HashMap::new())
-            .take(max_guesses)
+        let known_states = std::iter::repeat_n(HashMap::new(), max_guesses)
             .collect::<Vec<_>>();
 
-        let known_counts = std::iter::repeat(HashMap::new())
-            .take(max_guesses)
+        let known_counts = std::iter::repeat_n(HashMap::new(), max_guesses)
             .collect::<Vec<_>>();
 
         let mut game = Self {
@@ -179,7 +174,7 @@ impl Sanuli {
 
         game.refresh();
 
-        return Some(game);
+        Some(game)
     }
 
     pub fn new_or_rehydrate(
@@ -446,19 +441,16 @@ impl Game for Sanuli {
 
         self.guesses = Vec::with_capacity(self.max_guesses);
 
-        self.known_states = std::iter::repeat(HashMap::new())
-            .take(self.max_guesses)
+        self.known_states = std::iter::repeat_n(HashMap::new(), self.max_guesses)
             .collect::<Vec<_>>();
-        self.known_counts = std::iter::repeat(HashMap::new())
-            .take(self.max_guesses)
+        self.known_counts = std::iter::repeat_n(HashMap::new(), self.max_guesses)
             .collect::<Vec<_>>();
 
         if previous_word.len() == self.word_length
             && self.is_winner
             && self.game_mode == GameMode::Relay
         {
-            let empty_guesses = std::iter::repeat(Vec::with_capacity(self.word_length))
-                .take(self.max_guesses - 1)
+            let empty_guesses = std::iter::repeat_n(Vec::with_capacity(self.word_length), self.max_guesses - 1)
                 .collect::<Vec<_>>();
 
             self.guesses.push(
@@ -481,8 +473,7 @@ impl Game for Sanuli {
             );
             self.current_guess = 1;
         } else {
-            self.guesses = std::iter::repeat(Vec::with_capacity(self.word_length))
-                .take(self.max_guesses)
+            self.guesses = std::iter::repeat_n(Vec::with_capacity(self.word_length), self.max_guesses)
                 .collect::<Vec<_>>();
             self.current_guess = 0;
         }
@@ -638,7 +629,7 @@ impl Game for Sanuli {
             .replace("/", ".")
             .replace("=", "_");
 
-        return Some(format!("{}/?peli={}", base_url, safe_str));
+        Some(format!("{}/?peli={}", base_url, safe_str))
     }
 
     fn reveal_hidden_tiles(&mut self) {
@@ -647,8 +638,7 @@ impl Game for Sanuli {
     }
 
     fn reset(&mut self) {
-        self.guesses = std::iter::repeat(Vec::with_capacity(self.word_length))
-            .take(self.max_guesses)
+        self.guesses = std::iter::repeat_n(Vec::with_capacity(self.word_length), self.max_guesses)
             .collect::<Vec<_>>();
 
         self.current_guess = 0;
@@ -660,24 +650,20 @@ impl Game for Sanuli {
         self.is_hidden = false;
         self.message = "Peli nollattu, arvaa sanuli!".to_owned();
 
-        self.known_states = std::iter::repeat(HashMap::new())
-            .take(self.max_guesses)
+        self.known_states = std::iter::repeat_n(HashMap::new(), self.max_guesses)
             .collect::<Vec<_>>();
 
-        self.known_counts = std::iter::repeat(HashMap::new())
-            .take(self.max_guesses)
+        self.known_counts = std::iter::repeat_n(HashMap::new(), self.max_guesses)
             .collect::<Vec<_>>();
 
         self.previous_guesses = Vec::new();
     }
 
     fn refresh(&mut self) {
-        self.known_states = std::iter::repeat(HashMap::new())
-            .take(self.max_guesses)
+        self.known_states = std::iter::repeat_n(HashMap::new(), self.max_guesses)
             .collect::<Vec<_>>();
 
-        self.known_counts = std::iter::repeat(HashMap::new())
-            .take(self.max_guesses)
+        self.known_counts = std::iter::repeat_n(HashMap::new(), self.max_guesses)
             .collect::<Vec<_>>();
 
         // Rerun the game to refresh known_states and known_counts


### PR DESCRIPTION
(Mostly) LLM-produced lint fixes. Cargo clippy gives very specific suggestions, so there's not much the robot needed to think or decide.

The web_sys_unstable_apis fixing was more manual.

# After
```
$ cargo build
   Compiling sanuli v0.1.0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.01s
$ cargo clippy
    Checking sanuli v0.1.0
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.94s
```

# Before
```
$ cargo build                                                                                                                                                                                                     [16:28:13]
   Compiling sanuli v0.1.0
warning: unexpected `cfg` condition name: `web_sys_unstable_apis`
   --> src/manager.rs:537:11
    |
537 |     #[cfg(web_sys_unstable_apis)]
    |           ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: expected names are: `docsrs`, `feature`, and `test` and 31 more
    = help: consider using a Cargo feature instead
    = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
             [lints.rust]
             unexpected_cfgs = { level = "warn", check-cfg = ['cfg(web_sys_unstable_apis)'] }
    = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(web_sys_unstable_apis)");` to the top of the `build.rs`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
    = note: `#[warn(unexpected_cfgs)]` on by default

warning: unexpected `cfg` condition name: `web_sys_unstable_apis`
   --> src/manager.rs:542:11
    |
542 |     #[cfg(web_sys_unstable_apis)]
    |           ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a Cargo feature instead
    = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
             [lints.rust]
             unexpected_cfgs = { level = "warn", check-cfg = ['cfg(web_sys_unstable_apis)'] }
    = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(web_sys_unstable_apis)");` to the top of the `build.rs`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration

warning: unexpected `cfg` condition name: `web_sys_unstable_apis`
   --> src/main.rs:175:23
    |
175 |                 #[cfg(web_sys_unstable_apis)]
    |                       ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a Cargo feature instead
    = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
             [lints.rust]
             unexpected_cfgs = { level = "warn", check-cfg = ['cfg(web_sys_unstable_apis)'] }
    = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(web_sys_unstable_apis)");` to the top of the `build.rs`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration

warning: unexpected `cfg` condition name: `web_sys_unstable_apis`
   --> src/main.rs:189:23
    |
189 |                 #[cfg(web_sys_unstable_apis)]
    |                       ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: consider using a Cargo feature instead
    = help: or consider adding in `Cargo.toml` the `check-cfg` lint config for the lint:
             [lints.rust]
             unexpected_cfgs = { level = "warn", check-cfg = ['cfg(web_sys_unstable_apis)'] }
    = help: or consider adding `println!("cargo::rustc-check-cfg=cfg(web_sys_unstable_apis)");` to the top of the `build.rs`
    = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration

warning: methods `share_emojis` and `share_link` are never used
  --> src/game.rs:24:8
   |
17 | pub trait Game {
   |           ---- methods in this trait
...
24 |     fn share_emojis(&self, theme: Theme) -> Option<String>;
   |        ^^^^^^^^^^^^
25 |     fn share_link(&self) -> Option<String>;
   |        ^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default

warning: `sanuli` (bin "sanuli") generated 5 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.19s
```
...and much more from clippy ;)
```
$ cargo clippy 2>&1 |wc
     674    2638   33007
``` 